### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 {
     "name": "timhysniu/wp-cli-template",
     "description": "Find, list and update templates for WP-CLI",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/timhysniu/wp-cli-template",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
